### PR TITLE
RCP-303-MEMBER-SPRING-EVENT

### DIFF
--- a/src/main/java/com/recipia/member/adapter/in/listener/springevent/SpringEventRecordListener.java
+++ b/src/main/java/com/recipia/member/adapter/in/listener/springevent/SpringEventRecordListener.java
@@ -3,6 +3,7 @@ package com.recipia.member.adapter.in.listener.springevent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.recipia.member.application.port.in.MemberEventRecordUseCase;
 import com.recipia.member.common.event.NicknameChangeSpringEvent;
+import com.recipia.member.common.event.SignUpSpringEvent;
 import com.recipia.member.domain.MemberEventRecord;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -23,6 +24,16 @@ public class SpringEventRecordListener {
     @EventListener
     public void eventRecordListener(NicknameChangeSpringEvent event) throws JsonProcessingException {
         MemberEventRecord memberEventRecord = MemberEventRecord.of(event.memberId(), String.valueOf(NicknameChangeSpringEvent.class));
+        memberEventRecordUseCase.saveNewEventRecord(memberEventRecord);
+    }
+
+    /**
+     * 회원가입 후 이벤트 발행 여부를 기록 (transactional out box pattern)
+     */
+    @Transactional
+    @EventListener
+    public void signUpListener(SignUpSpringEvent event) throws JsonProcessingException {
+        MemberEventRecord memberEventRecord = MemberEventRecord.of(event.memberId(), String.valueOf(SignUpSpringEvent.class));
         memberEventRecordUseCase.saveNewEventRecord(memberEventRecord);
     }
 

--- a/src/main/java/com/recipia/member/adapter/in/listener/springevent/SpringEventSnsPublishListener.java
+++ b/src/main/java/com/recipia/member/adapter/in/listener/springevent/SpringEventSnsPublishListener.java
@@ -3,6 +3,7 @@ package com.recipia.member.adapter.in.listener.springevent;
 import brave.Tracer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.recipia.member.adapter.out.aws.SeoulSnsService;
+import com.recipia.member.common.event.SignUpSpringEvent;
 import com.recipia.member.common.utils.CustomJsonBuilder;
 import com.recipia.member.common.event.NicknameChangeSpringEvent;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,23 @@ public class SpringEventSnsPublishListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void snsPublishListener(NicknameChangeSpringEvent event) throws JsonProcessingException {
+
+        // 현재 TraceID 추출
+        String traceId = tracer.currentSpan().context().traceIdString();
+
+        // message에 memberId 주입
+        String messageJson = customJsonBuilder
+                .add("memberId", event.memberId().toString())
+                .build();
+
+        seoulSnsService.publishNicknameToTopic(messageJson, traceId);
+    }
+
+    /**
+     * 회원가입시 호출되어 SNS에 메시지를 발행한다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void signUpSnsPublishListener(SignUpSpringEvent event) throws JsonProcessingException {
 
         // 현재 TraceID 추출
         String traceId = tracer.currentSpan().context().traceIdString();

--- a/src/main/java/com/recipia/member/application/service/SignUpService.java
+++ b/src/main/java/com/recipia/member/application/service/SignUpService.java
@@ -2,11 +2,13 @@ package com.recipia.member.application.service;
 
 import com.recipia.member.application.port.in.SignUpUseCase;
 import com.recipia.member.application.port.out.port.SignUpPort;
+import com.recipia.member.common.event.SignUpSpringEvent;
 import com.recipia.member.common.exception.ErrorCode;
 import com.recipia.member.common.exception.MemberApplicationException;
 import com.recipia.member.domain.Member;
 import com.recipia.member.domain.MemberFile;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +19,7 @@ public class SignUpService implements SignUpUseCase {
 
     private final SignUpPort signUpPort;
     private final ImageS3Service imageS3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     @Override
@@ -41,6 +44,10 @@ public class SignUpService implements SignUpUseCase {
                 throw new MemberApplicationException(ErrorCode.MEMBER_FILE_SAVE_ERROR);
             }
         }
+
+        // 이벤트 발행: 레시피 서버에 회원가입된 유저 정보 저장
+        eventPublisher.publishEvent(SignUpSpringEvent.of(savedMemberId));
+
         return savedMemberId;
     }
 

--- a/src/main/java/com/recipia/member/common/event/SignUpSpringEvent.java
+++ b/src/main/java/com/recipia/member/common/event/SignUpSpringEvent.java
@@ -1,0 +1,12 @@
+package com.recipia.member.common.event;
+
+/**
+ * 회원가입 스프링 이벤트 발행
+ */
+public record SignUpSpringEvent(
+        Long memberId
+) {
+    public static SignUpSpringEvent of(Long memberId) {
+        return new SignUpSpringEvent(memberId);
+    }
+}


### PR DESCRIPTION
1. 회원가입시 스프링 이벤트를 발행하여 레시피 서버의 DB에 멤버 정보를 전달하도록 코드 작성
2. transaction outbox pattern을 적용하여 2개의 리스너가 동작하도록 함 (DB에 이벤트 기록, SNS에 메시지 발행)