### PR TITLE
RCP-304-MEMBER-SNS-BATCH

### DIFF
--- a/src/main/java/com/recipia/member/adapter/in/listener/springevent/SpringEventSnsPublishListener.java
+++ b/src/main/java/com/recipia/member/adapter/in/listener/springevent/SpringEventSnsPublishListener.java
@@ -6,6 +6,7 @@ import com.recipia.member.adapter.out.aws.SeoulSnsService;
 import com.recipia.member.common.event.SignUpSpringEvent;
 import com.recipia.member.common.utils.CustomJsonBuilder;
 import com.recipia.member.common.event.NicknameChangeSpringEvent;
+import com.recipia.member.config.aws.SnsConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,7 @@ public class SpringEventSnsPublishListener {
 
     private final SeoulSnsService seoulSnsService;
     private final CustomJsonBuilder customJsonBuilder;
+    private final SnsConfig snsConfig;
     private final Tracer tracer;
 
     /**
@@ -35,7 +37,8 @@ public class SpringEventSnsPublishListener {
                 .add("memberId", event.memberId().toString())
                 .build();
 
-        seoulSnsService.publishNicknameToTopic(messageJson, traceId);
+        String snsArn = snsConfig.getNicknameChangeArn();
+        seoulSnsService.publishSnsMessage(messageJson, traceId, snsArn);
     }
 
     /**
@@ -52,7 +55,8 @@ public class SpringEventSnsPublishListener {
                 .add("memberId", event.memberId().toString())
                 .build();
 
-        seoulSnsService.publishNicknameToTopic(messageJson, traceId);
+        String snsArn = snsConfig.getSignUpArn();
+        seoulSnsService.publishSnsMessage(messageJson, traceId, snsArn);
     }
 
 }

--- a/src/main/java/com/recipia/member/adapter/out/aws/SeoulSnsService.java
+++ b/src/main/java/com/recipia/member/adapter/out/aws/SeoulSnsService.java
@@ -22,11 +22,10 @@ import java.util.Map;
 public class SeoulSnsService {
 
     private final SnsClient snsClient;
-    private final SnsConfig snsConfig;
     private final Tracer tracer;
 
 
-    public PublishResponse publishNicknameToTopic(String message, String traceId) {
+    public PublishResponse publishSnsMessage(String message, String traceId, String snsArn) {
 
         // SNS 발행 Span 생성
         Span span = tracer.nextSpan().name("SNS Publish").start();
@@ -43,7 +42,7 @@ public class SeoulSnsService {
             PublishRequest publishRequest = PublishRequest.builder()
                     .message(message)
                     .messageAttributes(messageAttributes)
-                    .topicArn(snsConfig.getSnsTopicNicknameChangeARN())
+                    .topicArn(snsArn)
                     .build();
 
             // SNS 클라이언트를 통해 메시지 발행

--- a/src/main/java/com/recipia/member/application/service/MemberEventRecordService.java
+++ b/src/main/java/com/recipia/member/application/service/MemberEventRecordService.java
@@ -48,7 +48,7 @@ public class MemberEventRecordService implements MemberEventRecordUseCase {
                 .add("memberId", memberId)
                 .build();
 
-        String topicName = MemberStringUtils.extractLastPart(snsConfig.getSnsTopicNicknameChangeARN());
+        String topicName = MemberStringUtils.extractLastPart(snsConfig.getNicknameChangeArn());
 
         // 이벤트 저장소에 이벤트 저장하기 전에 기존에 누락되었던(published = false) 동일한 이벤트는 전부 발행 처리(published = true)로 수정
         memberEventRecordPort.changeBeforeEventAllPublishedToTrue(memberId, topicName);

--- a/src/main/java/com/recipia/member/config/aws/SnsConfig.java
+++ b/src/main/java/com/recipia/member/config/aws/SnsConfig.java
@@ -24,7 +24,10 @@ public class SnsConfig {
     private String awsRegion;
 
     @Value("${spring.cloud.aws.sns.topics.nickname-change}")
-    private String snsTopicNicknameChangeARN;
+    private String nicknameChangeArn;
+
+    @Value("${spring.cloud.aws.sns.topics.signUp}")
+    private String signUpArn;
 
     @Bean
     public SnsClient getSnsClient () {

--- a/src/main/java/com/recipia/member/config/batch/BatchConfig.java
+++ b/src/main/java/com/recipia/member/config/batch/BatchConfig.java
@@ -1,8 +1,8 @@
 package com.recipia.member.config.batch;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.recipia.member.adapter.out.aws.SeoulSnsService;
 import com.recipia.member.adapter.out.persistence.MemberEventRecordEntity;
+import com.recipia.member.config.aws.SnsConfig;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +33,7 @@ public class BatchConfig extends DefaultBatchConfiguration {
 
     private final SeoulSnsService seoulSnsService;
     private final EntityManagerFactory entityManagerFactory;
-    private final ObjectMapper objectMapper;
+    private final SnsConfig snsConfig;
 
 
     // 배치 작업에서 사용할 chunkSize 값 설정. 기본값은 1000
@@ -107,7 +107,8 @@ public class BatchConfig extends DefaultBatchConfiguration {
             log.info("processItem 동작중");
 
             switch (item.getSnsTopic()) {
-                case "NicknameChange" -> seoulSnsService.publishNicknameToTopic(item.getAttribute(), item.getTraceId());
+                case "NicknameChange" -> seoulSnsService.publishSnsMessage(item.getAttribute(), item.getTraceId(), snsConfig.getNicknameChangeArn());
+                case "signUp" -> seoulSnsService.publishSnsMessage(item.getAttribute(), item.getTraceId(), snsConfig.getSignUpArn());
             }
             return item;
         };

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,7 @@ spring:
       sns:
         topics:
           nickname-change: arn:aws:sns:${REGION}:${ACCOUNT_ID}:NicknameChange
+          signUp: arn:aws:sns:${REGION}:${ACCOUNT_ID}:signUp
       sqs:
         record-sqs-name: member-event-record-sqs
       s3:


### PR DESCRIPTION
1. 공통 로직을 공유하도록 코드 수정
2. SNS 발행 코드 추가 (기존 SNS 토픽에 회원가입 전용 토픽 생성)
3. 이벤트 재발행을 위한 배치코드 수정