### PR TITLE
RCP-362-MEMBER-IMAGE-BUG-FIX

### DIFF
--- a/src/main/java/com/recipia/member/application/service/ImageS3Service.java
+++ b/src/main/java/com/recipia/member/application/service/ImageS3Service.java
@@ -42,7 +42,7 @@ public class ImageS3Service {
     /**
      * 데이터베이스에 저장할 MemberFile 객체를 생성하여 반환한다.
      */
-    public MemberFile createMemberFile(MultipartFile image, Long savedMemberId) {
+    public MemberFile createMemberFile(MultipartFile image, Long savedMemberId, Integer fileOrder) {
 
         // 1. input 파라미터 검증
         validateInput(image, savedMemberId);
@@ -51,9 +51,6 @@ public class ImageS3Service {
         // 2. 파일 확장자 추출 및 검증
         String fileExtension = getFileExtension(originFileName);
         validateFileExtension(fileExtension);
-
-        // file order는 1부터 시작
-        Integer fileOrder = memberPort.findMaxFileOrder(savedMemberId) + 1;
 
         // 3. 파일 도메인을 만들기 위한 값 세팅
         String storedFileNameWithExtension = changeFileName(fileExtension); // 새로 생성된 이미지 이름 (UUID 적용)

--- a/src/main/java/com/recipia/member/application/service/MyPageService.java
+++ b/src/main/java/com/recipia/member/application/service/MyPageService.java
@@ -25,6 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 마이페이지 서비스 클래스
@@ -100,8 +101,12 @@ public class MyPageService implements MyPageUseCase {
 
         // 5. 수정된 profileImage가 있다면 저장한다.
         if (profileImage != null && !profileImage.isEmpty()) {
+
+            // 순차적으로 file order를 올리기 위한 변수 선언
+            AtomicInteger currentMaxFileOrder = new AtomicInteger(memberPort.findMaxFileOrder(myPage.getMemberId()));
+
             // 프로필 파일 저장을 위한 엔티티 생성 (이때 s3에는 이미 이미지가 업로드 완료되고 저장된 경로의 url을 받은 엔티티를 리스트로 생성)
-            MemberFile memberFile = imageS3Service.createMemberFile(profileImage, memberId);
+            MemberFile memberFile = imageS3Service.createMemberFile(profileImage, memberId, currentMaxFileOrder.incrementAndGet());
             Long savedMemberFileId = memberPort.saveMemberFile(memberFile);
 
             if (savedMemberFileId < 1) {

--- a/src/main/java/com/recipia/member/application/service/SignUpService.java
+++ b/src/main/java/com/recipia/member/application/service/SignUpService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * 회원가입 서비스 클래스
  */
@@ -53,8 +55,12 @@ public class SignUpService implements SignUpUseCase {
 
         // 5. 프로필 이미지가 없으면 파일을 저장하지 않는다.
         if(profileImage != null && !profileImage.isEmpty()) {
+
+            // 순차적으로 file order를 올리기 위한 변수 선언
+            AtomicInteger currentMaxFileOrder = new AtomicInteger(memberPort.findMaxFileOrder(savedMemberId));
+
             // 프로필 파일 저장을 위한 엔티티 생성 (이때 s3에는 이미 이미지가 업로드 완료되고 저장된 경로의 url을 받은 엔티티를 리스트로 생성)
-            MemberFile memberFile = imageS3Service.createMemberFile(profileImage, savedMemberId);
+            MemberFile memberFile = imageS3Service.createMemberFile(profileImage, savedMemberId, currentMaxFileOrder.incrementAndGet());
             Long savedMemberFileId = memberPort.saveMemberFile(memberFile);
 
             if(savedMemberFileId < 0) {

--- a/src/test/java/com/recipia/member/application/service/ImageS3ServiceTest.java
+++ b/src/test/java/com/recipia/member/application/service/ImageS3ServiceTest.java
@@ -59,7 +59,7 @@ class ImageS3ServiceTest extends TotalTestSupport {
         Long memberId = 123L;
 
         //when
-        MemberFile memberFile = sut.createMemberFile(mockImage, memberId);
+        MemberFile memberFile = sut.createMemberFile(mockImage, memberId, 1);
 
         //then
         assertNotNull(memberFile);
@@ -79,7 +79,7 @@ class ImageS3ServiceTest extends TotalTestSupport {
                 "file", "test.txt", "text/plain", "This is a text file.".getBytes());
 
         //when & then
-        Assertions.assertThatThrownBy(() -> sut.createMemberFile(mockFile, 1L))
+        Assertions.assertThatThrownBy(() -> sut.createMemberFile(mockFile, 1L, 1))
                 .isInstanceOf(MemberApplicationException.class)
                 .hasMessageContaining("S3에 업로드 할 수 없는 파일 타입입니다.")
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FILE_TYPE);
@@ -93,7 +93,7 @@ class ImageS3ServiceTest extends TotalTestSupport {
                 "image", "empty.jpg", "image/jpeg", new byte[100]);
 
         //when & then
-        Assertions.assertThatThrownBy(() -> sut.createMemberFile(mockImage, null))
+        Assertions.assertThatThrownBy(() -> sut.createMemberFile(mockImage, null, 1))
                 .isInstanceOf(MemberApplicationException.class)
                 .hasMessageContaining("유저를 찾을 수 없습니다.")
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
@@ -103,10 +103,9 @@ class ImageS3ServiceTest extends TotalTestSupport {
     @DisplayName("[bad] 저장할 파일이 없는 경우 예외가 발생한다.")
     void createMemberFileEntityException3() {
         Long memberId = 123L;
-        Integer fileOrder = 0;
 
         //when & then
-        Assertions.assertThatThrownBy(() -> sut.createMemberFile(null, memberId))
+        Assertions.assertThatThrownBy(() -> sut.createMemberFile(null, memberId, 1))
                 .isInstanceOf(MemberApplicationException.class)
                 .hasMessageContaining("업로드할 파일이 존재하지 않습니다.")
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.S3_UPLOAD_FILE_NOT_FOUND);

--- a/src/test/java/com/recipia/member/application/service/MyPageServiceTest.java
+++ b/src/test/java/com/recipia/member/application/service/MyPageServiceTest.java
@@ -129,7 +129,7 @@ class MyPageServiceTest {
         // then
         assertEquals(updatedCount, 1L);
         verify(memberPort, never()).softDeleteProfileImage(any(MyPage.class));
-        verify(imageS3Service, never()).createMemberFile(any(MultipartFile.class), anyLong());
+        verify(imageS3Service, never()).createMemberFile(any(MultipartFile.class), anyLong(), anyInt());
         verify(memberPort, never()).saveMemberFile(any(MemberFile.class));
     }
 
@@ -148,7 +148,7 @@ class MyPageServiceTest {
         // then
         assertEquals(updatedCount, 1L);
         verify(memberPort, times(1)).softDeleteProfileImage(any(MyPage.class));
-        verify(imageS3Service, never()).createMemberFile(any(MultipartFile.class), anyLong());
+        verify(imageS3Service, never()).createMemberFile(any(MultipartFile.class), anyLong(), anyInt());
         verify(memberPort, never()).saveMemberFile(any(MemberFile.class));
     }
 
@@ -165,7 +165,7 @@ class MyPageServiceTest {
 
         when(memberPort.findMemberByIdAndStatus(myPage.getMemberId(), MemberStatus.ACTIVE)).thenReturn(member);
         when(myPagePort.updateMyPage(myPage)).thenReturn(1L);
-        when(imageS3Service.createMemberFile(mockImage, myPage.getMemberId())).thenReturn(memberFile);
+        when(imageS3Service.createMemberFile(mockImage, myPage.getMemberId(), 1)).thenReturn(memberFile);
         when(memberPort.saveMemberFile(memberFile)).thenReturn(2L);
 
         // when
@@ -187,7 +187,7 @@ class MyPageServiceTest {
 
         when(memberPort.findMemberByIdAndStatus(myPage.getMemberId(), MemberStatus.ACTIVE)).thenReturn(member);
         when(myPagePort.updateMyPage(myPage)).thenReturn(1L);
-        when(imageS3Service.createMemberFile(mockImage, myPage.getMemberId())).thenReturn(memberFile);
+        when(imageS3Service.createMemberFile(mockImage, myPage.getMemberId(), 1)).thenReturn(memberFile);
         when(memberPort.saveMemberFile(memberFile)).thenReturn(0L);
 
         // when % then

--- a/src/test/java/com/recipia/member/application/service/SignUpServiceTest.java
+++ b/src/test/java/com/recipia/member/application/service/SignUpServiceTest.java
@@ -58,7 +58,7 @@ class SignUpServiceTest {
         verify(signUpPort, times(1)).signUpMember(any(Member.class));
 
         // 검증: 프로필 이미지가 null이므로, imageS3Service.createMemberFile가 호출되지 않았는지 확인
-        verify(imageS3Service, never()).createMemberFile(any(MultipartFile.class), anyLong());
+        verify(imageS3Service, never()).createMemberFile(any(MultipartFile.class), anyLong(), anyInt());
     }
 
 }


### PR DESCRIPTION
1. 이미지 저장할때 file order 순차적으로 올라가도록 코드 수정